### PR TITLE
Make Nano Defender for Firefox auto updateable

### DIFF
--- a/Extension Compiler/Extension/manifest.json
+++ b/Extension Compiler/Extension/manifest.json
@@ -56,10 +56,12 @@
     "webRequest",
     "webRequestBlocking"
   ],
-  "version": "13.59",
+  "version": "13.60",
   "applications": {
     "gecko": {
-      "strict_min_version": "57.0"
+      "id":"NanoDefender@krystian3w",
+      "strict_min_version": "57.0",
+      "update_url": "https://raw.githubusercontent.com/krystian3w/NanoDefenderFirefox/master/Extension%20Compiler/updates.json"
     }
   }
 }

--- a/Extension Compiler/updates.json
+++ b/Extension Compiler/updates.json
@@ -1,0 +1,14 @@
+{
+ "addons": {
+  "NanoDefender@krystian3w": {
+   "updates": [
+    {
+     "version": "13.60",
+     "applications": { "gecko": { "strict_min_version": "57.0" } },
+     "update_info_url": "https://github.com/krystian3w/NanoDefenderFirefox/tree/13.60",
+     "update_link": "https://github.com/krystian3w/NanoDefenderFirefox/releases/download/13.60/nano_defender-13.60-an.fx.xpi"
+    }
+   ]
+  }
+ }
+} 


### PR DESCRIPTION
### Explain why is this change needed (required): 
Do automatycznej aktualizacji :smile:

### Add everything else that you believe to be useful below (optional): 
`https://developer.mozilla.org/en-US/Add-ons/Updates`


Przy każdej aktualizacji trzeba zmieniać wersję i link do nowej wersji w updates.json, by to działało :smile:.
